### PR TITLE
Removes unessary word in density matrix notebook

### DIFF
--- a/content/ch-quantum-hardware/density-matrix.ipynb
+++ b/content/ch-quantum-hardware/density-matrix.ipynb
@@ -3131,7 +3131,7 @@
     "\\rho_{kk} = \\sum_{j} p_j \\alpha_{k}^{(j)} \\left ( \\alpha_{k}^{(j)} \\right )^* = \\sum_{j} p_j |\\alpha_{k}^{(j)} |^{2}\n",
     "$$\n",
     "\n",
-    "Here, $|\\alpha_{k}^{(j)} |^{2}$ is corresponds to probability of finding the basis state $|\\phi_k \\rangle$ within a given $ |\\psi_j \\rangle $ state, so summing over all $p_j$ values gives us the total probability of the whole system being in state $|\\phi_k \\rangle$.\n",
+    "Here, $|\\alpha_{k}^{(j)} |^{2}$ corresponds to probability of finding the basis state $|\\phi_k \\rangle$ within a given $ |\\psi_j \\rangle $ state, so summing over all $p_j$ values gives us the total probability of the whole system being in state $|\\phi_k \\rangle$.\n",
     "\n",
     "On the other hand, the off-diagonal terms of the matrix are a measure of the *coherence* between the different basis states of the system. In other words, they can be used to quantify how a pure superposition state could evolve (decohere) into a mixed state.\n",
     "\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
